### PR TITLE
Do not use the deprecated set-env command.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
         wget -O kubebuilder.tgz https://go.kubebuilder.io/dl/2.3.1/linux/amd64;
         tar -C /tmp/ -xzf kubebuilder.tgz;
         rm kubebuilder.tgz;
-        echo "::set-env name=KUBEBUILDER_ASSETS::/tmp/kubebuilder_2.3.1_linux_amd64/bin"
+        echo "KUBEBUILDER_ASSETS=/tmp/kubebuilder_2.3.1_linux_amd64/bin" >> $GITHUB_ENV
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
     - name: Get dependencies

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ The operator works based on a CustomResourceDefinition that manages the Varnish 
 Example of a simple `VarnishCluster`:
 
 ```yaml
-apiVersion: ibm.com/v1alpha1
+apiVersion: caching.ibm.com/v1alpha1
 kind: VarnishCluster
 metadata:
   labels:

--- a/docs/development.md
+++ b/docs/development.md
@@ -118,7 +118,7 @@ docker push <image-name>
 Then, in your `VarnishCluster`, specify your image:
 
 ```yaml
-apiVersion: ibm.com/v1alpha1
+apiVersion: caching.ibm.com/v1alpha1
 kind: VarnishCluster
 ...
 spec:


### PR DESCRIPTION
Also fix wrong API group in readme and docs