### PR TITLE
Cleanup only available VCLs. 

### DIFF
--- a/pkg/varnishcontroller/controller/controller_varnish.go
+++ b/pkg/varnishcontroller/controller/controller_varnish.go
@@ -57,7 +57,7 @@ func (r *ReconcileVarnish) reconcileVarnish(ctx context.Context, vc *v1alpha1.Va
 
 	// cleanup unused VCLs. It cleans up only VCLs created by varnish controller (those that start with our prefix)
 	for _, vclConfig := range configsList {
-		if vclConfig.Status != varnishadm.VCLStatusActive && strings.HasPrefix(vclConfig.Name, VCLVersionPrefix) {
+		if vclConfig.Status == varnishadm.VCLStatusAvailable && strings.HasPrefix(vclConfig.Name, VCLVersionPrefix) {
 			err := r.varnish.Discard(vclConfig.Name)
 			if err != nil {
 				return errors.Wrapf(err, "Can't delete VCL config %q", vclConfig.Name)

--- a/pkg/varnishcontroller/varnishadm/varnishadm.go
+++ b/pkg/varnishcontroller/varnishadm/varnishadm.go
@@ -17,6 +17,8 @@ const (
 	VCLStatusAvailable = "available"
 	//VCLStatusActive - VCL configuration is active now
 	VCLStatusActive = "active"
+	//VCLStatusDiscarded - VCL configuration is discarded but still in use by in-flight requests
+	VCLStatusDiscarded = "discarded"
 	//VCLTemperatureCold - vanish VCL "temperature"
 	VCLTemperatureCold = "cold"
 	//VCLTemperatureWarm for preloaded varnish's VCL


### PR DESCRIPTION
Fixes deletion of an already discarded VCL.

It happened when the operator discarded a VCL that was in use by requests still in-flight. Those VCLs won't get deleted until those requests finish and still appear in `vcl.list` output, making the operator try to delete it again. We should delete only `available` vcls and don't touch `discarded` and `active` vcls.

Resolves #29.

Signed-off-by: Tomash Sidei <tomash.sidei@ibm.com>