### PR TITLE
Fix rbac configuration to access lease resource

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -105,6 +105,17 @@ rules:
   - patch
   - update
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors

--- a/pkg/varnishcluster/controller/varnishcluster_controller.go
+++ b/pkg/varnishcluster/controller/varnishcluster_controller.go
@@ -175,6 +175,7 @@ func NewVarnishReconciler(mgr manager.Manager, cfg *config.Config, logr *logger.
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=list;watch;create;update;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings;clusterroles;clusterrolebindings,verbs=list;watch;create;update;delete
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;delete
 
 func (r *ReconcileVarnishCluster) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	logr := r.logger.With(logger.FieldVarnishCluster, request.Name)

--- a/varnish-operator/templates/clusterrole.yaml
+++ b/varnish-operator/templates/clusterrole.yaml
@@ -105,6 +105,17 @@ rules:
   - patch
   - update
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors


### PR DESCRIPTION
Came across this while testing leader election in the varnish operator. Need to add permissions to allow access to the `lease` resource within the `coordination.k8s.io` api group for the leader election lease to be successfully acquired.

Resolves #33.