### PR TITLE
Fix bug when VCL is not loaded when only the container and not the whole pod is restarted

### DIFF
--- a/pkg/varnishcontroller/events/events.go
+++ b/pkg/varnishcontroller/events/events.go
@@ -11,6 +11,8 @@ const (
 
 	EventReasonReloadError         EventReason = "ReloadError"
 	EventReasonVCLCompilationError EventReason = "VCLCompilationError"
+	EventReasonInvalidVCLConfigMap EventReason = "InvalidVCLConfigMap"
+	EventReasonBackendIgnored      EventReason = "BackendIgnored"
 
 	annotationSourcePod string = "sourcePod"
 )


### PR DESCRIPTION
resolves #67 
Also:
* Fire an event and log the case when a backend pod is found but couldn't fine the port definition we're looking for.
* Fire an event if both a templated and not templated version of a VCL file is set in the VCL ConfigMap.

Signed-off-by: Tomash Sidei <tomash.sidei@ibm.com>