### PR TITLE
feat(workflow/docs): add event push on branch main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,9 @@ on:
   release:
     types:
       - created
+  push:
+    branches:
+      - main
 
 jobs:
   docs:


### PR DESCRIPTION
# Why 
I noticed last merge, that the documentation was modified but it wasn't regenerated as we didn't change the release tag. I would like for the Documentation to be regenerated each time a new commit goes to `main`.

# How

Adding the event push for branch main would launch the workflow each time a commit is added to `main`. 


# Issue
https://github.com/IBM/varnish-operator/issues/91