### PR TITLE
doc(vcl/sharding): add precision and fix acl syntax 

### DIFF
--- a/docs/vcl-configuration.md
+++ b/docs/vcl-configuration.md
@@ -307,7 +307,7 @@ backend {{ .PodName }} {
 // Create ACL with Varnish cluster members
 acl acl_cluster {
   {{ range .VarnishNodes }}
-  "{{ .IP }}"/32;
+  "{{ .IP }}/32";
   {{ end }}
 }
 

--- a/docs/vcl-configuration.md
+++ b/docs/vcl-configuration.md
@@ -369,7 +369,7 @@ sub vcl_recv {
   if (req.http.X-shard == server.identity || remote.ip ~ acl_cluster) {
     set req.backend_hint = real.backend();
   } else {
-    return(pass);
+    return(pass); // Can be hash here you if want to load the answer in the local cache of calling Varnish instance
   }
 
   return (hash);


### PR DESCRIPTION
# Why 
I had issues line 310 with the syntax and since I added `/32` inside the quotes it worked.
I added precision line 372, it can be `hash` and if you set it to `hash` it will load the answer into the cache of your varnish instance, versus `pass` it will ask for the answer each time and will not load it into Varnish instance's cache. 

Thanks,
Arthur 

# Issue.
#104 